### PR TITLE
Bad checksum: neofinder

### DIFF
--- a/Casks/neofinder.rb
+++ b/Casks/neofinder.rb
@@ -1,6 +1,6 @@
 cask 'neofinder' do
   version '7.3.3'
-  sha256 '9c4c34cd81c0f5d9f320aa923bedaae9ff86d8e8a78b414e4eaf0303b68b0678'
+  sha256 '3131d72eebaf96b20b7db1b5888d08f29784c4464575cc25f20fc63a8a22dbec'
 
   # wfs-apps.de was verified as official when first introduced to the cask
   url "https://www.wfs-apps.de/updates/neofinder.#{version}.zip"


### PR DESCRIPTION
Not sure if the file is corrupt, or the [checksum](https://github.com/Homebrew/homebrew-cask/blob/master/doc/cask_language_reference/stanzas/sha256.md#updating-the-sha256) from https://github.com/Homebrew/homebrew-cask/pull/60683/files#r272237865 is bad...